### PR TITLE
Add basic frontend i18n

### DIFF
--- a/Frontend/src/main/java/org/pinguweb/frontend/view/ContactView.java
+++ b/Frontend/src/main/java/org/pinguweb/frontend/view/ContactView.java
@@ -10,12 +10,21 @@ import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.i18n.I18NProvider;
+import com.vaadin.flow.i18n.LocaleChangeEvent;
+import com.vaadin.flow.i18n.LocaleChangeObserver;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @Route(value = "contact", layout = MainLayout.class)
-public class ContactView extends VerticalLayout {
+public class ContactView extends VerticalLayout implements LocaleChangeObserver {
 
     private final I18NProvider i18n;
+    private Image illus;
+    private Image icon;
+    private H2 title;
+    private Text subtitle;
+    private Div subtitleDiv;
+    private Div infoText;
+    private Button copyBtn;
 
     @Autowired
     public ContactView(I18NProvider i18n) {
@@ -41,7 +50,7 @@ public class ContactView extends VerticalLayout {
                 .set("width", "100%")
                 .set("margin-top", "64px");
 
-        Image illus = new Image("icons/Support.png", getTranslation("contact.title"));
+        illus = new Image("icons/Support.png", getTranslation("contact.title"));
         illus.setWidth("110px");
         illus.setHeight("110px");
         illus.getStyle().set("margin-bottom", "15px").set("border-radius", "12px");
@@ -49,19 +58,19 @@ public class ContactView extends VerticalLayout {
         HorizontalLayout header = new HorizontalLayout();
         header.setAlignItems(FlexComponent.Alignment.CENTER);
 
-        Image icon = new Image("https://cdn-icons-png.flaticon.com/512/561/561127.png", getTranslation("contact.title"));
+        icon = new Image("https://cdn-icons-png.flaticon.com/512/561/561127.png", getTranslation("contact.title"));
         icon.setWidth("32px");
         icon.setHeight("32px");
 
-        H2 title = new H2(getTranslation("contact.title"));
+        title = new H2(getTranslation("contact.title"));
         title.getStyle().set("margin", "0 0 0 10px").set("font-size", "1.5rem");
         header.add(icon, title);
 
-        Text subtitle = new Text(getTranslation("contact.subtitle"));
-        Div subtitleDiv = new Div(subtitle);
+        subtitle = new Text(getTranslation("contact.subtitle"));
+        subtitleDiv = new Div(subtitle);
         subtitleDiv.getStyle().set("margin-bottom", "8px");
 
-        Div infoText = new Div(new Text(getTranslation("contact.info")));
+        infoText = new Div(new Text(getTranslation("contact.info")));
         infoText.getStyle().set("font-size", "0.98em").set("margin-bottom", "12px").set("color", "#555");
 
         Hr divider = new Hr();
@@ -70,7 +79,7 @@ public class ContactView extends VerticalLayout {
         Anchor mail = new Anchor("mailto:nbarrie@upv.edu.es", "nbarrie@upv.edu.es");
         mail.getStyle().set("font-weight", "bold").set("color", "#2563eb").set("font-size", "1.07em");
 
-        Button copyBtn = new Button(getTranslation("contact.copy"), e -> {
+        copyBtn = new Button(getTranslation("contact.copy"), e -> {
             getUI().ifPresent(ui ->
                     ui.getPage().executeJs("navigator.clipboard.writeText($0)", "nbarrie@upv.edu.es")
             );
@@ -93,5 +102,15 @@ public class ContactView extends VerticalLayout {
 
     private String getTranslation(String key) {
         return i18n.getTranslation(key, getLocale());
+    }
+
+    @Override
+    public void localeChange(LocaleChangeEvent event) {
+        illus.setAlt(getTranslation("contact.title"));
+        icon.setAlt(getTranslation("contact.title"));
+        title.setText(getTranslation("contact.title"));
+        subtitle.setText(getTranslation("contact.subtitle"));
+        infoText.setText(getTranslation("contact.info"));
+        copyBtn.setText(getTranslation("contact.copy"));
     }
 }

--- a/Frontend/src/main/java/org/pinguweb/frontend/view/LoginView.java
+++ b/Frontend/src/main/java/org/pinguweb/frontend/view/LoginView.java
@@ -15,6 +15,8 @@ import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.i18n.I18NProvider;
+import com.vaadin.flow.i18n.LocaleChangeEvent;
+import com.vaadin.flow.i18n.LocaleChangeObserver;
 import org.springframework.beans.factory.annotation.Autowired;
 import lombok.extern.slf4j.Slf4j;
 import org.pinguweb.frontend.objects.LoginRequest;
@@ -27,9 +29,11 @@ import org.springframework.web.client.RestTemplate;
 @Route("login")
 @PageTitle("Admin · Solidarity Hub")
 @CssImport("./styles/loginView.css")
-public class LoginView extends VerticalLayout {
+public class LoginView extends VerticalLayout implements LocaleChangeObserver {
 
     private final I18NProvider i18n;
+    private LoginForm loginForm;
+    private Button back;
 
     @Autowired
     public LoginView(I18NProvider i18n) {
@@ -45,10 +49,10 @@ public class LoginView extends VerticalLayout {
     }
 
     private void createLoginForm() {
-        LoginForm loginForm = new LoginForm();
+        loginForm = new LoginForm();
         loginForm.addClassName("login-form");
 
-        LoginI18n loginI18n = LoginI18n.createDefault();
+        LoginI18n loginI18n = createI18n();
 
         loginI18n.getForm().setTitle(getTranslation("login.title"));
         loginI18n.getForm().setUsername(getTranslation("login.username"));
@@ -56,12 +60,6 @@ public class LoginView extends VerticalLayout {
         loginI18n.getForm().setSubmit(getTranslation("login.submit"));
         loginI18n.getForm().setForgotPassword(getTranslation("login.forgot"));
 
-        LoginI18n.ErrorMessage errorMessage = new LoginI18n.ErrorMessage();
-        errorMessage.setTitle(getTranslation("login.error.title"));
-        errorMessage.setMessage(getTranslation("login.error.message"));
-
-        loginI18n.setErrorMessage(errorMessage);
-        loginForm.setI18n(loginI18n);
         loginForm.setI18n(loginI18n);
 
         loginForm.addLoginListener(e -> {
@@ -92,12 +90,29 @@ public class LoginView extends VerticalLayout {
         });
 
         Icon arrow = VaadinIcon.ARROW_LEFT.create();
-        Button back = new Button(getTranslation("login.back"), arrow);
+        back = new Button(getTranslation("login.back"), arrow);
         back.getStyle().set("gap", "0.5em");
         back.addClassName("back-button");
         back.addClickListener(e -> getUI().ifPresent(ui -> ui.navigate("")));
 
         add(loginForm, back);
+    }
+
+    private LoginI18n createI18n() {
+        LoginI18n loginI18n = LoginI18n.createDefault();
+
+        loginI18n.getForm().setTitle(getTranslation("login.title"));
+        loginI18n.getForm().setUsername(getTranslation("login.username"));
+        loginI18n.getForm().setPassword(getTranslation("login.password"));
+        loginI18n.getForm().setSubmit(getTranslation("login.submit"));
+        loginI18n.getForm().setForgotPassword(getTranslation("login.forgot"));
+
+        LoginI18n.ErrorMessage errorMessage = new LoginI18n.ErrorMessage();
+        errorMessage.setTitle(getTranslation("login.error.title"));
+        errorMessage.setMessage(getTranslation("login.error.message"));
+
+        loginI18n.setErrorMessage(errorMessage);
+        return loginI18n;
     }
 
     private boolean authenticate(LoginRequest req) {
@@ -111,5 +126,11 @@ public class LoginView extends VerticalLayout {
 
     private String getTranslation(String key) {
         return i18n.getTranslation(key, getLocale());
+    }
+
+    @Override
+    public void localeChange(LocaleChangeEvent event) {
+        loginForm.setI18n(createI18n());
+        back.setText(getTranslation("login.back"));
     }
 }

--- a/Frontend/src/main/java/org/pinguweb/frontend/view/MainView.java
+++ b/Frontend/src/main/java/org/pinguweb/frontend/view/MainView.java
@@ -16,20 +16,30 @@ import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.i18n.I18NProvider;
+import com.vaadin.flow.i18n.LocaleChangeEvent;
+import com.vaadin.flow.i18n.LocaleChangeObserver;
 import jakarta.annotation.security.PermitAll;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Locale;
 
-import org.springframework.beans.factory.annotation.Autowired;
-
 @Route("")
 @PageTitle("")
 @PermitAll
 @CssImport("./styles/mainView.css")
-public class MainView extends VerticalLayout {
+public class MainView extends VerticalLayout implements LocaleChangeObserver {
 
     private final I18NProvider i18n;
+
+    private H1 modalTitle;
+    private Paragraph modalText;
+    private Button closeModal;
+    private H1 title;
+    private Paragraph subtitle;
+    private Button login;
+    private Button home;
+    private Button whatIsSHUB;
+    private ComboBox<String> lang;
 
     @Autowired
     public MainView(I18NProvider i18n) {
@@ -44,9 +54,9 @@ public class MainView extends VerticalLayout {
         aboutDialog.setCloseOnEsc(true);
         aboutDialog.setCloseOnOutsideClick(true);
 
-        H1 modalTitle = new H1(getTranslation("about.title"));
-        Paragraph modalText = new Paragraph(getTranslation("about.text"));
-        Button closeModal = new Button(getTranslation("about.close"), e -> aboutDialog.close());
+        modalTitle = new H1(getTranslation("about.title"));
+        modalText = new Paragraph(getTranslation("about.text"));
+        closeModal = new Button(getTranslation("about.close"), e -> aboutDialog.close());
 
         VerticalLayout dialogLayout = new VerticalLayout(modalTitle, modalText, closeModal);
         dialogLayout.setDefaultHorizontalComponentAlignment(Alignment.CENTER);
@@ -61,14 +71,14 @@ public class MainView extends VerticalLayout {
         content.setWidthFull();
         content.setHeightFull();
 
-        H1 title = new H1(getTranslation("main.title"));
+        title = new H1(getTranslation("main.title"));
         title.addClassName("content-title");
 
-        Paragraph subtitle = new Paragraph(getTranslation("main.subtitle"));
+        subtitle = new Paragraph(getTranslation("main.subtitle"));
         subtitle.addClassName("content-subtitle");
 
         Icon arrow = VaadinIcon.ARROW_RIGHT.create();
-        Button login = new Button(getTranslation("main.login"), arrow, e ->
+        login = new Button(getTranslation("main.login"), arrow, e ->
                 getUI().ifPresent(ui -> ui.navigate("login"))
         );
         login.setIconAfterText(true);
@@ -109,12 +119,12 @@ public class MainView extends VerticalLayout {
 
     // 3. Ahora el layout de botones recibe el Dialog para abrirlo desde el botón
     private HorizontalLayout getHorizontalLayout(Dialog aboutDialog) {
-        Button home = new Button(getTranslation("header.home"), e -> UI.getCurrent().navigate(""));
-        Button whatIsSHUB = new Button(getTranslation("header.about"), e -> aboutDialog.open());
+        home = new Button(getTranslation("header.home"), e -> UI.getCurrent().navigate(""));
+        whatIsSHUB = new Button(getTranslation("header.about"), e -> aboutDialog.open());
         home.addClassName("nav-button");
         whatIsSHUB.addClassName("nav-button");
 
-        ComboBox<String> lang = new ComboBox<>();
+        lang = new ComboBox<>();
         lang.setItems("Castellano", "English", "Valencià");
         lang.setValue(getCurrentLanguage());
         lang.addClassName("nav-combo");
@@ -138,8 +148,20 @@ public class MainView extends VerticalLayout {
             default -> new Locale("es");
         };
         UI.getCurrent().setLocale(locale);
+    }
+
+    @Override
+    public void localeChange(LocaleChangeEvent event) {
         UI.getCurrent().getPage().setTitle(getTranslation("app.title"));
-        UI.getCurrent().getPage().reload();
+        modalTitle.setText(getTranslation("about.title"));
+        modalText.setText(getTranslation("about.text"));
+        closeModal.setText(getTranslation("about.close"));
+        home.setText(getTranslation("header.home"));
+        whatIsSHUB.setText(getTranslation("header.about"));
+        title.setText(getTranslation("main.title"));
+        subtitle.setText(getTranslation("main.subtitle"));
+        login.setText(getTranslation("main.login"));
+        lang.setValue(getCurrentLanguage());
     }
 
     private String getCurrentLanguage() {

--- a/Frontend/src/main/resources/i18n/messages.properties
+++ b/Frontend/src/main/resources/i18n/messages.properties
@@ -1,8 +1,8 @@
 app.title=Bienvenido
 about.title=\u00bfQu\u00e9 es Solidarity Hub?
-about.text=Aqu\u00ed va tu texto explicando Solidarity Hub...
+about.text=Solidarity Hub es una plataforma (web y móvil) diseñada para coordinar y facilitar esfuerzos de ayuda solidaria en situaciones de emergencia o necesidad comunitaria.
 about.close=Cerrar
-header.home=Home
+header.home=Inicio
 header.about=Qu\u00e9 es SHUB
 main.title=Bienvenido al Proyecto Solidarity Hub
 main.subtitle=Inicia sesi\u00f3n para acceder a las funcionalidades.


### PR DESCRIPTION
## Summary
- add i18n provider with ES, EN and VA locales
- translate MainView, LoginView and ContactView
- add language combobox logic
- fix language switch using `LocaleChangeObserver`

## Testing
- `sh ./mvnw -q package -DskipTests` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_683f51a49e70832bb31132b19024b7b5